### PR TITLE
Allow null values to store the Optional MavenOptions.localRepository …

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
@@ -30,7 +30,7 @@ public class ProsperoInstallationManager implements InstallationManager {
     public ProsperoInstallationManager(Path installationDir, MavenOptions mavenOptions) throws Exception {
         this.server = installationDir;
         mavenSessionManager = new MavenSessionManager(
-                Optional.of(mavenOptions.getLocalRepository()), mavenOptions.isOffline());
+                Optional.ofNullable(mavenOptions.getLocalRepository()), mavenOptions.isOffline());
     }
 
     @Override


### PR DESCRIPTION
…value

Minor fix allowing to store null values for the localRepository on the optional passed to theMavenSessionManager