### PR TITLE
Update wording of revert operation to avoid 'update'

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
@@ -170,6 +170,22 @@ public class CliConsole implements Console {
         }
     }
 
+    public void changesFound(List<ArtifactChange> artifactUpdates) {
+        if (artifactUpdates.isEmpty()) {
+            getStdOut().println(CliMessages.MESSAGES.noChangesFound());
+        } else {
+            getStdOut().println(CliMessages.MESSAGES.changesFound());
+            for (ArtifactChange artifactUpdate : artifactUpdates) {
+                final Optional<String> newVersion = artifactUpdate.getNewVersion();
+                final Optional<String> oldVersion = artifactUpdate.getOldVersion();
+                final String artifactName = artifactUpdate.getArtifactName();
+
+                getStdOut().printf("  %-50s    %-20s ==>  %-20s%n", artifactName, oldVersion.orElse("[]"),
+                        newVersion.orElse("[]"));
+            }
+        }
+    }
+
     public boolean confirmUpdates() {
         return confirm(CliMessages.MESSAGES.continueWithUpdate(),
                 CliMessages.MESSAGES.applyingUpdates(),

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -105,8 +105,16 @@ public interface CliMessages {
         return bundle.getString("prospero.updates.header");
     }
 
+    default String changesFound() {
+        return bundle.getString("prospero.revert.changes.header");
+    }
+
     default String continueWithUpdate() {
         return bundle.getString("prospero.updates.prompt")  + " ";
+    }
+
+    default String continueWithRevert() {
+        return bundle.getString("prospero.revert.prompt")  + " ";
     }
 
     default String continueWithBuildUpdate() {
@@ -115,6 +123,10 @@ public interface CliMessages {
 
     default String updateCancelled() {
         return bundle.getString("prospero.updates.cancelled");
+    }
+
+    default String revertCancelled() {
+        return bundle.getString("prospero.revert.cancelled");
     }
 
     default String buildUpdateCancelled() {
@@ -135,6 +147,10 @@ public interface CliMessages {
 
     default String updateComplete() {
         return bundle.getString("prospero.updates.complete");
+    }
+
+    default String revertComplete(String revision) {
+        return String.format(bundle.getString("prospero.revert.complete"), revision);
     }
 
     default String buildUpdateComplete() {
@@ -390,7 +406,7 @@ public interface CliMessages {
     }
 
     default IllegalArgumentException updateCandidateStateNotMatched(Path targetDir, Path updateDir) {
-        return new IllegalArgumentException(String.format(bundle.getString("prospero.updates.apply.validation.candidate.outdated"), updateDir));
+        return new IllegalArgumentException(String.format(bundle.getString("prospero.updates.apply.validation.candidate.outdated"), targetDir, updateDir));
     }
 
     default IllegalArgumentException updateCandidateWrongType(Path updateDir, ApplyCandidateAction.Type operation) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -51,15 +51,17 @@ import static org.wildfly.prospero.cli.ReturnCodes.SUCCESS;
 public class RevertCommand extends AbstractParentCommand {
 
     private static int applyCandidate(CliConsole console, ApplyCandidateAction applyCandidateAction, boolean yes) throws OperationException, ProvisioningException {
-        console.updatesFound(applyCandidateAction.findUpdates().getArtifactUpdates());
+        console.changesFound(applyCandidateAction.findUpdates().getArtifactUpdates());
         final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
         FileConflictPrinter.print(conflicts, console);
 
-        if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithUpdate(), "", CliMessages.MESSAGES.updateCancelled())) {
+        if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithRevert(), "", CliMessages.MESSAGES.revertCancelled())) {
             return SUCCESS;
         }
 
         applyCandidateAction.applyUpdate(ApplyCandidateAction.Type.REVERT);
+
+        console.println(CliMessages.MESSAGES.revertComplete(applyCandidateAction.getCandidateRevision().getName()));
         return SUCCESS;
     }
 

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -9,15 +9,6 @@
 prospero.dist.name=${prospero.dist.name}
 
 #
-# Main Command Welcome Message
-#
-# This is only printed when running prospero without any parameters.
-
-prospero.welcomeMessage = @|bold Welcome to ${prospero.dist.name} CLI!|@\n\
-  \n\
-  This tool enables you to provision instances of the ${prospero.target.server} application server.\n
-
-#
 # General Usage Sections Headings
 #
 
@@ -30,7 +21,7 @@ usage.optionListHeading = %nOptions:%n
 #
 # Command Descriptions
 #
-prospero.usage.customSynopsis=             @|bold ${prospero.dist.name}|@ [@|fg(yellow) -hv|@] [COMMAND]
+${prospero.dist.name}.usage.customSynopsis=             @|bold ${prospero.dist.name}|@ [@|fg(yellow) -hv|@] [COMMAND]
 
 ${prospero.dist.name}.install.usage.header = Installs a new instance of the application server.
 ${prospero.dist.name}.install.usage.customSynopsis.0 =             @|bold ${prospero.dist.name} install|@ @|fg(yellow) --profile|@=@|italic <predefined-name>|@ [@|fg(yellow) OPTION|@]...
@@ -189,6 +180,14 @@ ${prospero.dist.name}.usage.footer = %nUse `${prospero.dist.name} <COMMAND> --he
 #
 # Prospero CLI messages
 #
+#
+# Main Command Welcome Message
+#
+# This is only printed when running prospero without any parameters.
+prospero.welcomeMessage = @|bold Welcome to ${prospero.dist.name} CLI!|@\n\
+  \n\
+  This tool enables you to provision and manage instances of the ${prospero.target.server} application server.\n
+
 prospero.install.agreement.prompt=Accept the agreement(s) [y/N]
 prospero.install.agreement.prompt.cancelled=Installation cancelled
 prospero.install.agreement.header=To install the requested server, following Agreements need to be accepted:
@@ -222,10 +221,15 @@ prospero.updates.prompt=Continue with update [y/N]:
 prospero.updates.cancelled=Update cancelled
 prospero.updates.complete=Update complete!
 
+prospero.revert.changes.header=Changes found:
+prospero.revert.prompt=Continue with revert [y/N]:
+prospero.revert.cancelled=Revert cancelled
+prospero.revert.complete=Server reverted to state %s.
+
 prospero.updates.apply.header=Applying updates
-prospero.updates.apply.validation.candidate.outdated=Unable to apply update.%n  Installation at [%s] has been updated since the update candidate [%s] was created.
-prospero.updates.apply.validation.candidate.wrong_type=Unable to apply update.%n  The candidate at [%s] was not prepared for %s operation.
-prospero.updates.apply.validation.candidate.not_candidate=Unable to apply update.%n  Installation at [%s] doesn't have a candidate marker file.
+prospero.updates.apply.validation.candidate.outdated=Unable to apply candidate.%n  Installation at [%s] has been updated since the update candidate [%s] was created.
+prospero.updates.apply.validation.candidate.wrong_type=Unable to apply candidate.%n  The candidate at [%s] was not prepared for %s operation.
+prospero.updates.apply.validation.candidate.not_candidate=Unable to apply candidate.%n  Installation at [%s] doesn't have a candidate marker file.
 
 prospero.updates.build.prompt=Continue with building update [y/N]:
 prospero.updates.build.cancelled=Build update cancelled

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertApplyCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertApplyCommandTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
+import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.api.exceptions.OperationException;
 import org.wildfly.prospero.cli.AbstractConsoleTest;
 import org.wildfly.prospero.cli.ActionFactory;
@@ -87,6 +88,7 @@ public class RevertApplyCommandTest extends AbstractConsoleTest {
         MetadataTestUtils.createGalleonProvisionedState(updateDir);
 
         when(applyCandidateAction.findUpdates()).thenReturn(new UpdateSet(Collections.emptyList()));
+        when(applyCandidateAction.getCandidateRevision()).thenReturn(new SavedState("abcd1234"));
     }
     @Test
     public void invalidInstallationDir() {

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertPerformCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertPerformCommandTest.java
@@ -96,6 +96,7 @@ public class RevertPerformCommandTest extends AbstractMavenCommandTest {
         MetadataTestUtils.createGalleonProvisionedState(installationDir);
 
         when(applyCandidateAction.findUpdates()).thenReturn(new UpdateSet(Collections.emptyList()));
+        when(applyCandidateAction.getCandidateRevision()).thenReturn(new SavedState("abcd1234"));
     }
     @Test
     public void invalidInstallationDir() {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -295,6 +295,17 @@ public class ApplyCandidateAction {
         return new UpdateSet(changes);
     }
 
+    /**
+     * returns the revision of the candidate server
+     * @return {@code SavedState}
+     * @throws MetadataException - if unable to read the candidate server metadata
+     */
+    public SavedState getCandidateRevision() throws MetadataException {
+        try (final InstallationMetadata metadata = InstallationMetadata.loadInstallation(updateDir)) {
+            return metadata.getRevisions().get(0);
+        }
+    }
+
     private boolean targetServerIsRunning() {
         return Files.exists(installationDir.resolve(STANDALONE_STARTUP_MARKER)) || Files.exists(installationDir.resolve(DOMAIN_STARTUP_MARKER));
     }


### PR DESCRIPTION
When listing changes applied by the revert:

```
Changes found:
 * io.undertow:undertow-core 2.2.18.Final => 2.2.17.Final

Continue with revert [y/N]: y

Server reverted to state ABCD1234
```

Rremove a warning about downgrading dependencies on revert.
