### PR TITLE
Replace JBOSS_HOME env var in start scripts

### DIFF
--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
@@ -74,22 +74,22 @@ rem $Id$
 )
 
 pushd "%DIRNAME%.."
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_PROSPERO_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%PROSPERO_HOME%" == "x" (
+  set "PROSPERO_HOME=%RESOLVED_PROSPERO_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%PROSPERO_HOME%"
+set "SANITIZED_PROSPERO_HOME=%CD%"
 popd
 
-if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+if /i "%RESOLVED_PROSPERO_HOME%" NEQ "%SANITIZED_PROSPERO_HOME%" (
    echo.
-   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo   WARNING:  PROSPERO_HOME may be pointing to a different installation - unpredictable results may occur.
    echo.
-   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo       PROSPERO_HOME: "%PROSPERO_HOME%"
    echo.
 )
 
@@ -106,7 +106,7 @@ if "%DEBUG_MODE%" == "true" (
 rem Set default log location
 echo "%JAVA_OPTS%" | findstr /I "org.wildfly.prospero.log.file" > nul
 if errorlevel == 1 (
-    set "JAVA_OPTS=%JAVA_OPTS% -Dorg.wildfly.prospero.log.file=%JBOSS_HOME%\logs\installation.log"
+    set "JAVA_OPTS=%JAVA_OPTS% -Dorg.wildfly.prospero.log.file=%PROSPERO_HOME%\logs\installation.log"
 )
 
 rem Setup JBoss specific properties
@@ -173,10 +173,10 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
 setlocal DisableDelayedExpansion
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%PROSPERO_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%PROSPERO_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%PROSPERO_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -190,7 +190,7 @@ setlocal DisableDelayedExpansion
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%PROSPERO_HOME%\modules"
 )
 
 setlocal EnableDelayedExpansion
@@ -222,14 +222,14 @@ setlocal EnableDelayedExpansion
 rem Add -client to the JVM options, if supported (32 bit VM), and not overridden
 echo "!MODULE_OPTS!" | findstr /I \-javaagent: > nul
 if not errorlevel == 1 (
-    set AGENT_PARAM=-javaagent:"!JBOSS_HOME!\jboss-modules.jar"
+    set AGENT_PARAM=-javaagent:"!PROSPERO_HOME!\jboss-modules.jar"
     set "JAVA_OPTS=!AGENT_PARAM! !JAVA_OPTS!"
 )
 setlocal DisableDelayedExpansion
 
 :RESTART
   "%JAVA%" %JAVA_OPTS% ^
-      -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+      -jar "%PROSPERO_HOME%\jboss-modules.jar" ^
       %MODULE_OPTS% ^
       -mp "%JBOSS_MODULEPATH%" ^
       org.jboss.prospero ^

--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.sh
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.sh
@@ -20,30 +20,30 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$PROSPERO_HOME" ] &&
+        PROSPERO_HOME=`cygpath --unix "$PROSPERO_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup PROSPERO_HOME
+RESOLVED_PROSPERO_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$PROSPERO_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    PROSPERO_HOME=$RESOLVED_PROSPERO_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_PROSPERO_HOME=`cd "$PROSPERO_HOME"; pwd`
+ if [ "$RESOLVED_PROSPERO_HOME" != "$SANITIZED_PROSPERO_HOME" ]; then
+   echo "WARNING PROSPERO_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export PROSPERO_HOME
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$PROSPERO_HOME/modules"
 fi
 
 # Setup the JVM
@@ -61,7 +61,7 @@ JAVA_OPTS="$JAVA_OPTS $DEFAULT_MODULAR_JVM_OPTIONS"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    PROSPERO_HOME=`cygpath --path --windows "$PROSPERO_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
@@ -80,7 +80,7 @@ JAVA_OPTS="$JAVA_OPTS -Dcom.ibm.jsse2.overrideDefaultTLS=true"
 # Set default log location
 LOG_FILE_CONF=`echo $JAVA_OPTS | grep "org.wildfly.prospero.log.file"`
 if [ "x$LOG_FILE_CONF" = "x" ]; then
-  JAVA_OPTS="$JAVA_OPTS -Dorg.wildfly.prospero.log.file=${JBOSS_HOME}/logs/installation.log"
+  JAVA_OPTS="$JAVA_OPTS -Dorg.wildfly.prospero.log.file=${PROSPERO_HOME}/logs/installation.log"
 fi
 
 # Sample JPDA settings for remote socket debugging
@@ -91,7 +91,7 @@ JBOSS_MODULEPATH=$(eval echo \"${JBOSS_MODULEPATH}\")
 
 LOG_CONF=`echo $JAVA_OPTS | grep "logging.configuration"`
 if [ "x$LOG_CONF" = "x" ]; then
-    exec "$JAVA" $JAVA_OPTS -Dlogging.configuration=file:"$JBOSS_HOME"/bin/${prospero.dist.name}-logging.properties -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.prospero "$@"
+    exec "$JAVA" $JAVA_OPTS -Dlogging.configuration=file:"$PROSPERO_HOME"/bin/${prospero.dist.name}-logging.properties -jar "$PROSPERO_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.prospero "$@"
 else
-    exec "$JAVA" $JAVA_OPTS -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.prospero "$@"
+    exec "$JAVA" $JAVA_OPTS -jar "$PROSPERO_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.prospero "$@"
 fi


### PR DESCRIPTION
Replacing JBOSS_HOME env variable in .sh and .bat scripts to avoid clashes with server configuration.
