### PR TITLE
Only fallback on Galleon Pack if the channel does not define a stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
         <version.junit>4.13.2</version.junit>
         <version.maven-shade-plugin>2.3</version.maven-shade-plugin>
-        <version.org.wildfly.channel>1.0.0.Final</version.org.wildfly.channel>
+        <version.org.wildfly.channel>1.0.1.Final</version.org.wildfly.channel>
         <version.maven-compiler-plugin>3.10.1</version.maven-compiler-plugin>
         <version.org.wildfly.galleon-pack>${prospero.base.feature-pack.version}</version.org.wildfly.galleon-pack>
         <version.info.picocli>4.6.3</version.info.picocli>

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManagerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManagerTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.wildfly.channel.ArtifactTransferException;
 import org.wildfly.channel.ChannelSession;
-import org.wildfly.channel.UnresolvedMavenArtifactException;
 
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
@@ -46,7 +46,7 @@ public class ChannelMavenArtifactRepositoryManagerTest {
     @Test
     public void testRequireChannelResolutionWhenFeaturePackVersionIsNotSpecified() throws Exception {
         when(session.resolveMavenArtifact("foo", "bar", "zip", "", null))
-                .thenThrow(UnresolvedMavenArtifactException.class);
+                .thenThrow(ArtifactTransferException.class);
 
 
         final MavenArtifact artifact = new MavenArtifact();

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
@@ -19,6 +19,7 @@ package org.wildfly.prospero.galleon;
 
 import org.jboss.galleon.ProvisioningException;
 import org.junit.Test;
+import org.wildfly.channel.ArtifactTransferException;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
 
 import java.nio.file.Paths;
@@ -54,7 +55,7 @@ public class GalleonUtilsTest {
     @Test
     public void extractFailedArtifactResolutionOnCopy() throws Exception {
         final ProvisioningException test = new ProvisioningException(
-                new UnresolvedMavenArtifactException("test", Collections.emptySet(), Collections.emptySet()));
+                new ArtifactTransferException("test", Collections.emptySet(), Collections.emptySet()));
         try {
             GalleonUtils.executeGalleon(o -> {
                 throw test;

--- a/prospero-common/src/test/java/org/wildfly/prospero/promotion/ArtifactPromoterTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/promotion/ArtifactPromoterTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.wildfly.channel.ArtifactTransferException;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.Repository;
@@ -264,7 +265,7 @@ public class ArtifactPromoterTest {
         final Optional<String> latestVersion = allVersions.stream().sorted(VersionMatcher.COMPARATOR.reversed()).findFirst();
 
         if (latestVersion.isEmpty()) {
-            throw new UnresolvedMavenArtifactException("No latestVersion", Collections.emptySet(), Collections.emptySet());
+            throw new ArtifactTransferException("No latestVersion", Collections.emptySet(), Collections.emptySet());
         }
 
         final File file = resolver.resolveArtifact(channelGa.getGroupId(), channelGa.getArtifactId(),

--- a/prospero-common/src/test/java/org/wildfly/prospero/updates/UpdateFinderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/updates/UpdateFinderTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.wildfly.channel.ArtifactTransferException;
 import org.wildfly.channel.ChannelSession;
-import org.wildfly.channel.UnresolvedMavenArtifactException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,7 +91,7 @@ public class UpdateFinderTest {
     @Test
     public void testRemoval() throws Exception {
         when(channelSession.findLatestMavenArtifactVersion("org.foo", "bar", "jar", "", null))
-                .thenThrow(new UnresolvedMavenArtifactException("Exception", Collections.emptySet(), Collections.emptySet()));
+                .thenThrow(new ArtifactTransferException("Exception", Collections.emptySet(), Collections.emptySet()));
 
         UpdateFinder finder = new UpdateFinder(channelSession);
         final List<Artifact> artifacts = Arrays.asList(


### PR DESCRIPTION
@jfdenise I think the fallback on galleon-defined versions should happen only if the channel doesn't define a stream. Otherwise it masks situation were desired version cannot be resolved due to e.g. repository issues. We should make similar change in wildfly-maven-plugin as well. WDYT?