### PR TITLE
[JBEAP-30446] Use ANSI codes to erase the line in the console

### DIFF
--- a/dist/common/src/main/licenses/licenses.xml
+++ b/dist/common/src/main/licenses/licenses.xml
@@ -321,6 +321,17 @@
             </licenses>
         </dependency>
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                    <distribution>repo</distribution>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
             <licenses>

--- a/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
+++ b/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
@@ -55,6 +55,7 @@
     <artifact name="${org.apache.maven.resolver:maven-resolver-transport-file}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-transport-http}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-util}"/>
+    <artifact name="${org.fusesource.jansi:jansi}"/>
   </resources>
 
   <dependencies>

--- a/dist/standalone-galleon-pack/pom.xml
+++ b/dist/standalone-galleon-pack/pom.xml
@@ -134,6 +134,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <exclusions>

--- a/dist/wildfly-galleon-pack/pom.xml
+++ b/dist/wildfly-galleon-pack/pom.xml
@@ -120,6 +120,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <version.org.jboss.galleon>6.0.6.Final</version.org.jboss.galleon>
         <version.org.eclipse.jgit>6.10.1.202505221210-r</version.org.eclipse.jgit>
         <version.com.fasterxml.jackson>2.17.0</version.com.fasterxml.jackson>
+        <version.org.fusesource.jansi>2.4.2</version.org.fusesource.jansi>
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
         <version.org.jboss.logging.slf4j-jboss-logmanager>2.0.1.Final</version.org.jboss.logging.slf4j-jboss-logmanager>
         <version.org.jboss.logging.jboss-logging-processor>2.2.1.Final</version.org.jboss.logging.jboss-logging-processor>
@@ -258,6 +259,12 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>${version.org.codehaus.plexus-utils}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>${version.org.fusesource.jansi}</version>
             </dependency>
 
             <dependency>

--- a/prospero-cli/pom.xml
+++ b/prospero-cli/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>json-schema-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.prospero</groupId>
             <artifactId>prospero-common</artifactId>
         </dependency>

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
@@ -136,9 +136,10 @@ public class CliMain {
     }
 
     static int execute(String[] args) {
-        CliConsole console = new CliConsole();
-        CommandLine commandLine = createCommandLine(console, args);
-        return commandLine.execute(args);
+        try (CliConsole console = new CliConsole()) {
+            CommandLine commandLine = createCommandLine(console, args);
+            return commandLine.execute(args);
+        }
     }
 
     static void logException(Exception e) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/DownloadsCallbackAdapter.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/DownloadsCallbackAdapter.java
@@ -26,7 +26,6 @@ import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.api.ProvisioningProgressEvent;
 
-import java.io.File;
 import java.util.HashSet;
 
 import static org.wildfly.prospero.galleon.GalleonEnvironment.TRACK_JB_ARTIFACTS_RESOLVE;
@@ -97,7 +96,8 @@ class DownloadsCallbackAdapter extends AbstractTransferListener implements Progr
             ProsperoLogger.ROOT_LOGGER.debug("Downloaded artifact: " + item);
         }
 
-        final int fileNameIndex = item.lastIndexOf(File.separator);
+        // note the fileName has Unix separators regardless of the actual OS
+        final int fileNameIndex = item.lastIndexOf("/");
         item = item.substring(fileNameIndex + 1);
         if (console != null) {
             if ("maven-metadata.xml".equals(item)) {


### PR DESCRIPTION
A few fixes related to displaying the installation progress bar

## leftover text when using translated texts

When using translated text with characters that don't fit single character space (e.g. chinese), the text erase mechanism can leave some text behind resulting in something like:

```
feature-packs が解決されました。                                                 at-00007
パッケージがインストールされました。40/541(100%) 
アーティファクトがダウンロードされました。                                           -00001-resources.jarjar7.jar1.jarjarjarararar
JBoss モジュールがインストールされました。91/492(100%) 
設定が生成されました。              を適用しています...    lancer.xml
JBoss の例がインストールされました。                    dalone-xts.xmljms.xmlxmld.xml
```

To fix that, we're adding jansi library and using ANSI escape codes to clear the text in the progress bar.

## skipping to next line of text

When terminal width is not enough to display the whole message, the progress bar can jump to a new line. This fix will truncate the message based on the actual width of the console

## displaying the downloaded artifact path on Windows

When downloading artifacts the file name of the downloaded jar should be displayed (e.g. `prospero-core-1.3.6.Final.jar`). However on Windows a whole path of the file is displayed.
