### PR TITLE
Update project URL

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,6 +1,6 @@
 name: WildFly Prospero 
 # Open the PR to do the PR from
-# the wildfly-extras/prospero repository
+# the wildfly/prospero repository
 release:
   current-version: 1.3.6.Final
   next-version: 1.3.7.Final-SNAPSHOT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ This is necessary because the testsuite poms do not contain all necessary module
 ### Issues
 ---
 
-You can find all issues under [Github Issues](https://github.com/wildfly-extras/prospero/issues) page. Once you have selected an issue you'd like to work on, make sure it's not already assigned to someone else.
+You can find all issues under [Github Issues](https://github.com/wildfly/prospero/issues) page. Once you have selected an issue you'd like to work on, make sure it's not already assigned to someone else.
 
 Check out our issues with the `good-first-issue` label. These are a triaged set of issues that are great for getting started on our project.
 

--- a/dist/docs/guide/channels/index.adoc
+++ b/dist/docs/guide/channels/index.adoc
@@ -1,6 +1,6 @@
 ## Working with channels
 
-More information on the Wildfly Channels can be found in https://github.com/wildfly-extras/wildfly-channel/blob/main/doc/spec.adoc. This chapter is intended to explain some concepts behind different channel types and how they can be used to provide software updates.
+More information on the Wildfly Channels can be found in https://github.com/wildfly/wildfly-channel/blob/main/doc/spec.adoc. This chapter is intended to explain some concepts behind different channel types and how they can be used to provide software updates.
 
 A channel contains a collections of artifact streams used by a server. Each stream should contain only backwards-compatible artifact updates with new versions of artifacts replacing previous ones.
 

--- a/dist/docs/guide/concepts/channels.adoc
+++ b/dist/docs/guide/concepts/channels.adoc
@@ -4,7 +4,7 @@ Wildfly Channels are a way to provide a curated list of compatible, up-to-date c
 
 There are two types of Wildfly Channels supported by Prospero - open channels and manifest channels. Open channels allow access to the latest artifacts in the underlying repository, while manifest channels define a list of allowed list of components.
 
-For more information on Wildfly Channels see the https://github.com/wildfly-extras/wildfly-channel/blob/main/doc/spec.adoc[spec documentation].
+For more information on Wildfly Channels see the https://github.com/wildfly/wildfly-channel/blob/main/doc/spec.adoc[spec documentation].
 
 #### Manifest channels
 

--- a/dist/docs/guide/overview/index.adoc
+++ b/dist/docs/guide/overview/index.adoc
@@ -12,6 +12,6 @@ The tool supports:
 
 Prospero includes a CLI client and a programmatic API.
 
-Releases of the command line tool will be available at https://github.com/wildfly-extras/prospero/releases/.
+Releases of the command line tool will be available at https://github.com/wildfly/prospero/releases/.
 
 To use the tool, download and unzip the release zip, then add the bin directory to your system path. Use `prospero.sh` or `prospero.bat` to launch the tool.

--- a/examples/wildfly-core-channel.yaml
+++ b/examples/wildfly-core-channel.yaml
@@ -6,4 +6,4 @@ repositories:
   - id: "jboss-public"
     url: "https://repository.jboss.org/nexus/content/groups/public/"
 manifest:
-  url: "https://raw.githubusercontent.com/wildfly-extras/prospero/main/examples/wildfly-core-manifest.yaml"
+  url: "https://raw.githubusercontent.com/wildfly/prospero/main/examples/wildfly-core-manifest.yaml"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <name>Prospero Parent</name>
     <description>Provisioning tool for the Wildfly application server.</description>
-    <url>https://github.com/wildfly-extras/prospero/</url>
+    <url>https://github.com/wildfly/prospero/</url>
 
     <licenses>
         <license>
@@ -60,9 +60,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:wildfly-extras/prospero.git</connection>
-        <developerConnection>scm:git:git@github.com:wildfly-extras/prospero.git</developerConnection>
-        <url>https://github.com/wildfly-extras/prospero</url>
+        <connection>scm:git:git@github.com:wildfly/prospero.git</connection>
+        <developerConnection>scm:git:git@github.com:wildfly/prospero.git</developerConnection>
+        <url>https://github.com/wildfly/prospero</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
after the project was transferred to the wildfly organization on GitHub

Note: Didn't find anything extra to add, so it's just cherry-pick from the main branch PR.