### PR TITLE
JBEAP-30876 - (8.0.8) installation-manager >8.0.4 update fails with symbolic link

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyStageBackup.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyStageBackup.java
@@ -9,6 +9,7 @@ import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -162,7 +163,7 @@ class ApplyStageBackup implements AutoCloseable {
 
         try {
             Files.createLink(backupPath, serverPath);
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | FileSystemException e) {
             Files.copy(serverPath, backupPath);
         }
     }


### PR DESCRIPTION
Upstream: NA
Jira: https://issues.redhat.com/browse/JBEAP-30876

It's not possible to create hardlinks on a different filesystem and it throws `FileSystemException` instead of `UnsupportedOperationException`:

```
Caused by: java.nio.file.FileSystemException: usb/.update.old/domain/configuration/mgmt-users.properties -> usb/domain/configuration/mgmt-users.properties: Invalid cross-device link
```