### PR TITLE
Change the dist/build/ submodule to pom packaging, to avoid producing…

### DIFF
--- a/dist/build/pom.xml
+++ b/dist/build/pom.xml
@@ -7,7 +7,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>prospero-build</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
 
     <name>Prospero Build</name>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -124,6 +124,7 @@
                     <groupId>org.wildfly.prospero</groupId>
                     <artifactId>prospero-build</artifactId>
                     <version>${project.version}</version>
+                    <type>zip</type>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>


### PR DESCRIPTION
… unneeded jar

This break JBoss Nexus and possibly Maven Central validations.

Resolves #963

This is preferred to #964 as a fix.

It ports https://github.com/wildfly/prospero/commit/b9ac334d2b3dba5441850fd5b360f43b18f7b1dd from 1.3.x