### PR TITLE
[JBEAP-31871] Prospero from main branch lists the channels in unexpected format

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
@@ -32,6 +32,7 @@ import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.metadata.ManifestVersionRecord;
+
 import picocli.CommandLine;
 
 @CommandLine.Command(name = CliConstants.Commands.CHANNEL)
@@ -79,6 +80,7 @@ public class ChannelCommand extends AbstractCommand {
                     console.println(ChannelMapper.toYaml(channels));
                 } else {
                         ChannelManifestCoordinate coordinate = channel.getManifestCoordinate();
+                        console.println("Use the --full parameter for a complete overview.");
                         if (coordinate != null) {
                             // Full Maven GAV
                             if (coordinate.getVersion() != null && !coordinate.getVersion().isEmpty()) {


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/JBEAP-31871

As requested on the issue, we added the new information about the new `--full` parameter