### PR TITLE
Fixing NPEs during upgrade operation

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
@@ -167,9 +167,11 @@ public class CliConsole implements Console {
                 ChannelVersion original = manifestUpdate.oldVersion();
                 ChannelVersion updated = manifestUpdate.newVersion();
                 String channelDescription = String.format("%s (%s)", original.getLocation(), channelName);
+                String originalPhysicalVersion = original.getPhysicalVersion();
+                String updatedPhysicalVersion = updated != null ? updated.getPhysicalVersion() : "-";
 
                 printf("  %s%-40s    %20s  ==>  %-20s%n", downgradeMarker(manifestUpdate.isDowngrade()),
-                        channelDescription, original.getPhysicalVersion(), updated.getPhysicalVersion(), channelName);
+                        channelDescription, originalPhysicalVersion, updatedPhysicalVersion, channelName);
             }
             println("");
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
@@ -71,7 +71,6 @@ public class ChannelUpdateFinder {
     public Collection<ChannelVersion> findNewerChannelVersions(Channel channel, String channelVersion)
             throws MetadataException {
         Objects.requireNonNull(channel);
-        Objects.requireNonNull(channelVersion);
 
         return retrieveArtifactVersions(channel, channelVersion);
     }


### PR DESCRIPTION
These happen in a scenario when upgrade is called after new channel has been subscribed, which was not part of the installation originally.