### PR TITLE
Message 'Use the --full parameter for a complete overview.' is displayed repeatedly

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
@@ -75,12 +75,15 @@ public class ChannelCommand extends AbstractCommand {
                 channels = metadataAction.getChannels();
             }
 
+            if(!fullList) {
+                console.println("Use the --full parameter for a complete overview.\n");
+            }
+
             for (Channel channel : channels) {
                 if (fullList) {
                     console.println(ChannelMapper.toYaml(channels));
                 } else {
                         ChannelManifestCoordinate coordinate = channel.getManifestCoordinate();
-                        console.println("Use the --full parameter for a complete overview.\n");
                         if (coordinate != null) {
                             // Full Maven GAV
                             if (coordinate.getVersion() != null && !coordinate.getVersion().isEmpty()) {


### PR DESCRIPTION
closes #1027