### PR TITLE
Csd modifications

### DIFF
--- a/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
+++ b/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
@@ -46,11 +46,13 @@
     <artifact name="${org.apache.maven:maven-model}"/>
     <artifact name="${org.apache.maven:maven-model-builder}"/>
     <artifact name="${org.apache.maven:maven-repository-metadata}"/>
+    <artifact name="${org.apache.maven:maven-resolver-provider}"/>
+    <artifact name="${org.apache.maven:maven-settings}"/>
+    <artifact name="${org.apache.maven:maven-settings-builder}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-api}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-connector-basic}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-impl}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-named-locks}"/>
-    <artifact name="${org.apache.maven:maven-resolver-provider}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-spi}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-transport-file}"/>
     <artifact name="${org.apache.maven.resolver:maven-resolver-transport-http}"/>

--- a/dist/standalone-galleon-pack/pom.xml
+++ b/dist/standalone-galleon-pack/pom.xml
@@ -332,6 +332,27 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.maven.resolver</groupId>
             <artifactId>maven-resolver-api</artifactId>
             <exclusions>

--- a/dist/wildfly-galleon-pack/pom.xml
+++ b/dist/wildfly-galleon-pack/pom.xml
@@ -218,6 +218,27 @@
       </exclusions>
     </dependency>
 
+      <dependency>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-settings</artifactId>
+          <exclusions>
+              <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-settings-builder</artifactId>
+          <exclusions>
+              <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
+
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <version.org.yaml.snakeyaml>2.4</version.org.yaml.snakeyaml>
         <version.junit>4.13.2</version.junit>
         <version.maven-shade-plugin>3.6.0</version.maven-shade-plugin>
-        <version.org.wildfly.channel>1.2.2.Final</version.org.wildfly.channel>
+        <version.org.wildfly.channel>1.2.3.Final</version.org.wildfly.channel>
         <version.maven-compiler-plugin>3.10.1</version.maven-compiler-plugin>
         <version.org.wildfly.galleon-pack>39.0.0.Final</version.org.wildfly.galleon-pack>
         <version.info.picocli>4.7.7</version.info.picocli>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,16 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings</artifactId>
+                <version>${version.org.apache.maven}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${version.org.apache.maven}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-interpolation</artifactId>
                 <version>${version.org.codehaus.plexus-interpolation}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <version.org.wildfly.galleon-plugins>8.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.installation-manager>1.2.1.Final</version.org.wildfly.installation-manager>
         <version.org.wildfly.maven.plugins.licenses-plugin>2.4.2.Final</version.org.wildfly.maven.plugins.licenses-plugin>
-        <version.org.wildfly.prospero.prospero-metadata>1.3.1.Final</version.org.wildfly.prospero.prospero-metadata>
+        <version.org.wildfly.prospero.prospero-metadata>1.3.2.Final</version.org.wildfly.prospero.prospero-metadata>
         <version.org.mockito>5.19.0</version.org.mockito>
         <version.org.slf4j>2.0.16</version.org.slf4j>
         <version.org.yaml.snakeyaml>2.4</version.org.yaml.snakeyaml>

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
@@ -85,6 +85,12 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
     )
     Optional<Path> mavenSettings = Optional.empty();
 
+    @CommandLine.Option(
+            names = CliConstants.FILTER_MANIFEST,
+            order = 8
+    )
+    Optional<Path> filterManifest = Optional.empty();
+
     public AbstractInstallCommand(CliConsole console, ActionFactory actionFactory) {
         super(console, actionFactory);
     }
@@ -93,6 +99,7 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
         final MavenOptions.Builder mavenOptions = localRepoOptions.toOptions();
         offline.map(mavenOptions::setOffline);
         mavenSettings.map(mavenOptions::setMavenSettingsPath);
+        filterManifest.map(mavenOptions::setFilterManifest);
         return mavenOptions.build();
     }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
@@ -79,6 +79,12 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
     )
     Optional<Boolean> offline = Optional.empty();
 
+    @CommandLine.Option(
+            names = CliConstants.MAVEN_SETTINGS,
+            order = 7
+    )
+    Optional<Path> mavenSettings = Optional.empty();
+
     public AbstractInstallCommand(CliConsole console, ActionFactory actionFactory) {
         super(console, actionFactory);
     }
@@ -86,6 +92,7 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
     protected MavenOptions getMavenOptions() throws ArgumentParsingException {
         final MavenOptions.Builder mavenOptions = localRepoOptions.toOptions();
         offline.map(mavenOptions::setOffline);
+        mavenSettings.map(mavenOptions::setMavenSettingsPath);
         return mavenOptions.build();
     }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -107,5 +107,6 @@ public final class CliConstants {
     public static final String YES = "--yes";
     public static final String NO_CONFLICTS_ONLY = "--no-conflicts-only";
     public static final String DRY_RUN = "--dry-run";
+    public static final String MAVEN_SETTINGS = "--maven-settings";
 
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -108,5 +108,6 @@ public final class CliConstants {
     public static final String NO_CONFLICTS_ONLY = "--no-conflicts-only";
     public static final String DRY_RUN = "--dry-run";
     public static final String MAVEN_SETTINGS = "--maven-settings";
+    public static final String FILTER_MANIFEST = "--filter-manifest";
 
 }

--- a/prospero-common/pom.xml
+++ b/prospero-common/pom.xml
@@ -43,6 +43,14 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-resolver-provider</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings-builder</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
@@ -156,7 +156,7 @@ class PrepareCandidateAction implements AutoCloseable {
                 manifestRecord);
 
         try {
-            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(galleonEnv.getChannels(), mavenSessionManager);
+            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(galleonEnv.getChannels(), mavenSessionManager, null);
             galleonFeaturePackAnalyzer.cacheGalleonArtifacts(targetDir, provisioningConfig);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
@@ -156,7 +156,7 @@ class PrepareCandidateAction implements AutoCloseable {
                 manifestRecord);
 
         try {
-            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(galleonEnv.getChannels(), mavenSessionManager, null);
+            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(galleonEnv.getChannels(), mavenSessionManager, null, null);
             galleonFeaturePackAnalyzer.cacheGalleonArtifacts(targetDir, provisioningConfig);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -135,6 +135,7 @@ public class ProvisioningAction {
                 .builder(installDir, channels, mavenSessionManager, false)
                 .setConsole(console)
                 .setProvisioningConfig(provisioningConfig)
+                .setMavenSettings(mvnOptions.getMavenSettings())
                 .build()) {
 
             try {
@@ -177,7 +178,8 @@ public class ProvisioningAction {
 
 
         try {
-            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(channels, mavenSessionManager);
+            final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(channels,
+                    mavenSessionManager, mvnOptions.getMavenSettings());
 
             if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                 ProsperoLogger.ROOT_LOGGER.debug("Recording accepted licenses");
@@ -222,7 +224,8 @@ public class ProvisioningAction {
         Objects.requireNonNull(provisioningConfig);
         Objects.requireNonNull(channels);
 
-        final GalleonFeaturePackAnalyzer exporter = new GalleonFeaturePackAnalyzer(channels, mavenSessionManager);
+        final GalleonFeaturePackAnalyzer exporter = new GalleonFeaturePackAnalyzer(channels, mavenSessionManager,
+                mvnOptions.getMavenSettings());
         return getPendingLicenses(provisioningConfig, exporter);
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -136,6 +136,7 @@ public class ProvisioningAction {
                 .setConsole(console)
                 .setProvisioningConfig(provisioningConfig)
                 .setMavenSettings(mvnOptions.getMavenSettings())
+                .setFilterManifest(mvnOptions.getFilterManifest())
                 .build()) {
 
             try {
@@ -179,7 +180,7 @@ public class ProvisioningAction {
 
         try {
             final GalleonFeaturePackAnalyzer galleonFeaturePackAnalyzer = new GalleonFeaturePackAnalyzer(channels,
-                    mavenSessionManager, mvnOptions.getMavenSettings());
+                    mavenSessionManager, mvnOptions.getMavenSettings(), mvnOptions.getFilterManifest());
 
             if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                 ProsperoLogger.ROOT_LOGGER.debug("Recording accepted licenses");
@@ -225,7 +226,7 @@ public class ProvisioningAction {
         Objects.requireNonNull(channels);
 
         final GalleonFeaturePackAnalyzer exporter = new GalleonFeaturePackAnalyzer(channels, mavenSessionManager,
-                mvnOptions.getMavenSettings());
+                mvnOptions.getMavenSettings(), mvnOptions.getFilterManifest());
         return getPendingLicenses(provisioningConfig, exporter);
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
@@ -202,7 +202,7 @@ public class MavenOptions {
         private Optional<Boolean> offline = Optional.empty();
         private Optional<Boolean> noLocalCache = Optional.empty();
         private Optional<Path> localCachePath = Optional.empty();
-        private Optional<Path> mavenSettingsPath = Optional.of(MavenOptions.DEFAULT_MAVEN_SETTINGS);
+        private Optional<Path> mavenSettingsPath = Optional.of(DEFAULT_MAVEN_SETTINGS);
         private Path filterManifest = null;
 
         private Builder() {

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
@@ -18,10 +18,13 @@
 package org.wildfly.prospero.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.io.DefaultSettingsReader;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -34,6 +37,9 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 
 public class MavenOptions {
+
+    private static final Path DEFAULT_MAVEN_SETTINGS = Path.of(System.getProperty("user.home"), ".m2/settings.xml");
+
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory()
             .configure(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
@@ -42,6 +48,8 @@ public class MavenOptions {
     private final Optional<Path> localCache;
     private final Optional<Boolean> offline;
     private final Optional<Boolean> noLocalCache;
+    @JsonIgnore
+    private final Optional<Path> mavenSettingsPath;
 
     public static final MavenOptions DEFAULT_OPTIONS = builder().build();
     public static final MavenOptions OFFLINE_NO_CACHE = builder()
@@ -64,12 +72,14 @@ public class MavenOptions {
         this.localCache = Optional.ofNullable(localCache).map(Path::toAbsolutePath);
         this.noLocalCache = Optional.of(noLocalCache);
         this.offline = Optional.of(offline);
+        this.mavenSettingsPath = Optional.of(DEFAULT_MAVEN_SETTINGS);
     }
 
-    private MavenOptions(Optional<Path> localCache, Optional<Boolean> offline, Optional<Boolean> noLocalCache) {
+    private MavenOptions(Optional<Path> localCache, Optional<Boolean> offline, Optional<Boolean> noLocalCache, Optional<Path> mavenSettings) {
         this.localCache = localCache;
         this.noLocalCache = noLocalCache;
         this.offline = offline;
+        this.mavenSettingsPath = mavenSettings;
     }
 
     public Path getLocalCache() {
@@ -89,12 +99,33 @@ public class MavenOptions {
         return localCache.isPresent();
     }
 
+    public Path getMavenSettingsPath() {
+        return mavenSettingsPath.orElse(null);
+    }
+
+    /**
+     * Parses the maven settings file
+     * @return Maven Settings instance
+     */
+    public Settings getMavenSettings() {
+        if (mavenSettingsPath.isEmpty() || !mavenSettingsPath.get().toFile().exists()) {
+            return null;
+        }
+        try {
+            DefaultSettingsReader settingsReader = new DefaultSettingsReader();
+            return settingsReader.read(mavenSettingsPath.get().toFile(), null);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't read settings.xml file: " + mavenSettingsPath.get(), e);
+        }
+    }
+
     @Override
     public String toString() {
         return "MavenOptions{" +
                 "localCache=" + localCache +
                 ", offline=" + offline +
                 ", noLocalCache=" + noLocalCache +
+                ", mavenSettings=" + mavenSettingsPath +
                 '}';
     }
 
@@ -117,6 +148,12 @@ public class MavenOptions {
         } else if (this.localCache.isPresent()) {
             builder.setLocalCachePath(this.getLocalCache());
         }
+
+        if (override.mavenSettingsPath.isPresent()) {
+            builder.setMavenSettingsPath(override.getMavenSettingsPath());
+        } else if (this.mavenSettingsPath.isPresent()) {
+            builder.setMavenSettingsPath(this.getMavenSettingsPath());
+        }
         return builder.build();
     }
 
@@ -135,12 +172,15 @@ public class MavenOptions {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MavenOptions that = (MavenOptions) o;
-        return Objects.equals(localCache, that.localCache) && Objects.equals(offline, that.offline) && Objects.equals(noLocalCache, that.noLocalCache);
+        return Objects.equals(localCache, that.localCache)
+                && Objects.equals(offline, that.offline)
+                && Objects.equals(noLocalCache, that.noLocalCache)
+                && Objects.equals(mavenSettingsPath, that.mavenSettingsPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(localCache, offline, noLocalCache);
+        return Objects.hash(localCache, offline, noLocalCache, mavenSettingsPath);
     }
 
     public static class Builder {
@@ -148,13 +188,13 @@ public class MavenOptions {
         private Optional<Boolean> offline = Optional.empty();
         private Optional<Boolean> noLocalCache = Optional.empty();
         private Optional<Path> localCachePath = Optional.empty();
+        private Optional<Path> mavenSettingsPath = Optional.of(MavenOptions.DEFAULT_MAVEN_SETTINGS);
 
         private Builder() {
-
         }
 
         public MavenOptions build() {
-            return new MavenOptions(localCachePath, offline, noLocalCache);
+            return new MavenOptions(localCachePath, offline, noLocalCache, mavenSettingsPath);
         }
 
         public Builder setOffline(boolean offline) {
@@ -169,6 +209,18 @@ public class MavenOptions {
 
         public Builder setLocalCachePath(Path localCachePath) {
             this.localCachePath = Optional.of(localCachePath);
+            return this;
+        }
+
+        /**
+         * Allows to specify location of the Maven settings file.
+         * <p>
+         * This parameter is currently not stored in installation metadata, it is only used for given command invocation.
+         *
+         * @param mavenSettings maven settings.xml file path, defaults to ~/.m2/settings.xml
+         */
+        public Builder setMavenSettingsPath(Path mavenSettings) {
+            this.mavenSettingsPath = Optional.of(mavenSettings);
             return this;
         }
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/MavenOptions.java
@@ -50,6 +50,7 @@ public class MavenOptions {
     private final Optional<Boolean> noLocalCache;
     @JsonIgnore
     private final Optional<Path> mavenSettingsPath;
+    private final Path filterManifest;
 
     public static final MavenOptions DEFAULT_OPTIONS = builder().build();
     public static final MavenOptions OFFLINE_NO_CACHE = builder()
@@ -73,13 +74,15 @@ public class MavenOptions {
         this.noLocalCache = Optional.of(noLocalCache);
         this.offline = Optional.of(offline);
         this.mavenSettingsPath = Optional.of(DEFAULT_MAVEN_SETTINGS);
+        this.filterManifest = null;
     }
 
-    private MavenOptions(Optional<Path> localCache, Optional<Boolean> offline, Optional<Boolean> noLocalCache, Optional<Path> mavenSettings) {
+    private MavenOptions(Optional<Path> localCache, Optional<Boolean> offline, Optional<Boolean> noLocalCache, Optional<Path> mavenSettings, Path filterManifest) {
         this.localCache = localCache;
         this.noLocalCache = noLocalCache;
         this.offline = offline;
         this.mavenSettingsPath = mavenSettings;
+        this.filterManifest = filterManifest;
     }
 
     public Path getLocalCache() {
@@ -119,6 +122,10 @@ public class MavenOptions {
         }
     }
 
+    public Path getFilterManifest() {
+        return filterManifest;
+    }
+
     @Override
     public String toString() {
         return "MavenOptions{" +
@@ -154,6 +161,13 @@ public class MavenOptions {
         } else if (this.mavenSettingsPath.isPresent()) {
             builder.setMavenSettingsPath(this.getMavenSettingsPath());
         }
+
+        if (override.filterManifest != null) {
+            builder.setFilterManifest(override.getFilterManifest());
+        } else if (this.filterManifest != null) {
+            builder.setFilterManifest(this.getFilterManifest());
+        }
+
         return builder.build();
     }
 
@@ -189,12 +203,13 @@ public class MavenOptions {
         private Optional<Boolean> noLocalCache = Optional.empty();
         private Optional<Path> localCachePath = Optional.empty();
         private Optional<Path> mavenSettingsPath = Optional.of(MavenOptions.DEFAULT_MAVEN_SETTINGS);
+        private Path filterManifest = null;
 
         private Builder() {
         }
 
         public MavenOptions build() {
-            return new MavenOptions(localCachePath, offline, noLocalCache, mavenSettingsPath);
+            return new MavenOptions(localCachePath, offline, noLocalCache, mavenSettingsPath, filterManifest);
         }
 
         public Builder setOffline(boolean offline) {
@@ -221,6 +236,16 @@ public class MavenOptions {
          */
         public Builder setMavenSettingsPath(Path mavenSettings) {
             this.mavenSettingsPath = Optional.of(mavenSettings);
+            return this;
+        }
+
+        /**
+         * Set filter manifest used to
+         * @param filterManifest
+         * @return
+         */
+        public Builder setFilterManifest(Path filterManifest) {
+            this.filterManifest = filterManifest;
             return this;
         }
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
@@ -108,8 +108,8 @@ public class GalleonEnvironment implements AutoCloseable {
 
         MavenVersionsResolver.Factory factory;
         try {
-            factory = new CachedVersionResolverFactory(new VersionResolverFactory(system, session, repositoryFactory),
-                    sourceServerPath, system, session);
+            factory = new ProsperoVersionResolverFactory(new VersionResolverFactory(system, session, repositoryFactory),
+                    sourceServerPath, system, session, builder.filterManifest);
         } catch (IOException e) {
             ProsperoLogger.ROOT_LOGGER.debug("Unable to read artifact cache, falling back to Maven resolver.", e);
             factory = new VersionResolverFactory(system, session, repositoryFactory);
@@ -287,6 +287,7 @@ public class GalleonEnvironment implements AutoCloseable {
         private List<ManifestVersionRecord.MavenManifest> restoredManifestVersions;
         private final boolean useDefaultCore;
         private Settings mavenSettings;
+        private Path filterManifest;
 
         private GalleonProvisioningConfig config;
 
@@ -350,8 +351,20 @@ public class GalleonEnvironment implements AutoCloseable {
             return this;
         }
 
+        /**
+         * Maven settings file to use for retrieving authentication credentials.
+         */
         public Builder setMavenSettings(Settings mavenSettings) {
             this.mavenSettings = mavenSettings;
+            return this;
+        }
+
+        /**
+         * Manifest used by version resolver to filter component versions. This is used to identify component versions
+         * intended for specific product stream.
+         */
+        public Builder setFilterManifest(Path filterManifest) {
+            this.filterManifest = filterManifest;
             return this;
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
@@ -18,6 +18,7 @@
 package org.wildfly.prospero.galleon;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.settings.Settings;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.jboss.galleon.ProvisioningException;
@@ -102,12 +103,16 @@ public class GalleonEnvironment implements AutoCloseable {
         final RepositorySystem system = builder.mavenSessionManager.newRepositorySystem();
         final DefaultRepositorySystemSession session = builder.mavenSessionManager.newRepositorySystemSession(system);
         final Path sourceServerPath = builder.sourceServerPath == null? builder.installDir:builder.sourceServerPath;
+        final RepositoryFactory repositoryFactory = new RepositoryFactory(List.of(
+                new MavenProxyHandler(), new RepositoryAuthenticationHandler(builder.mavenSettings)));
+
         MavenVersionsResolver.Factory factory;
         try {
-            factory = new CachedVersionResolverFactory(new VersionResolverFactory(system, session, MavenProxyHandler::addProxySettings), sourceServerPath, system, session);
+            factory = new CachedVersionResolverFactory(new VersionResolverFactory(system, session, repositoryFactory),
+                    sourceServerPath, system, session);
         } catch (IOException e) {
             ProsperoLogger.ROOT_LOGGER.debug("Unable to read artifact cache, falling back to Maven resolver.", e);
-            factory = new VersionResolverFactory(system, session, MavenProxyHandler::addProxySettings);
+            factory = new VersionResolverFactory(system, session, repositoryFactory);
         }
 
         channelSession = initChannelSession(session, factory);
@@ -281,6 +286,7 @@ public class GalleonEnvironment implements AutoCloseable {
         private boolean artifactDirectResolve;
         private List<ManifestVersionRecord.MavenManifest> restoredManifestVersions;
         private final boolean useDefaultCore;
+        private Settings mavenSettings;
 
         private GalleonProvisioningConfig config;
 
@@ -341,6 +347,11 @@ public class GalleonEnvironment implements AutoCloseable {
          */
         public Builder setArtifactDirectResolve(boolean artifactDirectResolve) {
             this.artifactDirectResolve = artifactDirectResolve;
+            return this;
+        }
+
+        public Builder setMavenSettings(Settings mavenSettings) {
+            this.mavenSettings = mavenSettings;
             return this;
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
@@ -18,6 +18,7 @@
 package org.wildfly.prospero.galleon;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.settings.Settings;
 import org.jboss.galleon.Constants;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.util.HashUtils;
@@ -44,10 +45,13 @@ public class GalleonFeaturePackAnalyzer {
 
     private final List<Channel> channels;
     private final MavenSessionManager mavenSessionManager;
+    private final Settings mavenSettings;
 
-    public GalleonFeaturePackAnalyzer(List<Channel> channels, MavenSessionManager mavenSessionManager) {
+    public GalleonFeaturePackAnalyzer(List<Channel> channels, MavenSessionManager mavenSessionManager,
+                                      Settings mavenSettings) {
         this.channels = channels;
         this.mavenSessionManager = mavenSessionManager;
+        this.mavenSettings = mavenSettings;
     }
 
     /**
@@ -143,6 +147,7 @@ public class GalleonFeaturePackAnalyzer {
                 .setSourceServerPath(sourcePath)
                 .setProvisioningConfig(provisioningConfig)
                 .setResolvedFpTracker(fps::add)
+                .setMavenSettings(mavenSettings)
                 .build();
         return galleonEnv;
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
@@ -46,12 +46,14 @@ public class GalleonFeaturePackAnalyzer {
     private final List<Channel> channels;
     private final MavenSessionManager mavenSessionManager;
     private final Settings mavenSettings;
+    private final Path filterManifest;
 
     public GalleonFeaturePackAnalyzer(List<Channel> channels, MavenSessionManager mavenSessionManager,
-                                      Settings mavenSettings) {
+                                      Settings mavenSettings, Path filterManifest) {
         this.channels = channels;
         this.mavenSessionManager = mavenSessionManager;
         this.mavenSettings = mavenSettings;
+        this.filterManifest = filterManifest;
     }
 
     /**
@@ -148,6 +150,7 @@ public class GalleonFeaturePackAnalyzer {
                 .setProvisioningConfig(provisioningConfig)
                 .setResolvedFpTracker(fps::add)
                 .setMavenSettings(mavenSettings)
+                .setFilterManifest(filterManifest)
                 .build();
         return galleonEnv;
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/MavenProxyHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/MavenProxyHandler.java
@@ -29,17 +29,25 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
-import static org.wildfly.channel.maven.VersionResolverFactory.DEFAULT_REPOSITORY_POLICY;
-
-class MavenProxyHandler {
+/**
+ * Configures repository proxy settings based on java proxy system properties like:
+ * <code>
+ *     https.proxyHost=http://proxyhost
+ *     https.proxyPort=8080
+ *     https.proxyUser=username
+ *     https.proxyPassword=password
+ * </code>
+ */
+class MavenProxyHandler implements RepositoryConversionHandler {
     private static final Logger LOG = Logger.getLogger(GalleonEnvironment.class.getName());
 
-    public static RemoteRepository addProxySettings(Repository r) {
+    @Override
+    public void accept(Repository repository, RemoteRepository.Builder builder) {
+        addProxySettings(repository, builder);
+    }
 
-        final RemoteRepository.Builder builder = new RemoteRepository.Builder(r.getId(), "default", r.getUrl())
-                .setPolicy(DEFAULT_REPOSITORY_POLICY);
-        getDefinedProxy(r).ifPresent(builder::setProxy);
-        return builder.build();
+    static void addProxySettings(Repository repository, RemoteRepository.Builder remoteRepositoryBuilder) {
+        getDefinedProxy(repository).ifPresent(remoteRepositoryBuilder::setProxy);
     }
 
     private static Optional<Proxy> getDefinedProxy(Repository r) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ProsperoVersionResolverFactory.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ProsperoVersionResolverFactory.java
@@ -23,6 +23,9 @@ import org.wildfly.channel.ArtifactCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.channel.spi.MavenVersionsResolver;
+import org.wildfly.prospero.galleon.artifactfiltering.ArtifactVersion;
+import org.wildfly.prospero.galleon.artifactfiltering.FilteringVersionResolver;
+import org.wildfly.prospero.galleon.artifactfiltering.ManifestBasedArtifactFilter;
 import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
@@ -31,26 +34,39 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
-public class CachedVersionResolverFactory implements MavenVersionsResolver.Factory {
+public class ProsperoVersionResolverFactory implements MavenVersionsResolver.Factory {
 
     private final VersionResolverFactory factory;
     private final RepositorySystem system;
     private final DefaultRepositorySystemSession session;
     private final ArtifactCache artifactCache;
     private final Path installDir;
+    private final Path filterManifest;
 
-    public CachedVersionResolverFactory(VersionResolverFactory factory, Path installDir, RepositorySystem system, DefaultRepositorySystemSession session) throws IOException {
+    public ProsperoVersionResolverFactory(VersionResolverFactory factory, Path installDir, RepositorySystem system, DefaultRepositorySystemSession session, Path filterManifest) throws IOException {
         this.factory = factory;
         this.system = system;
         this.session = session;
         this.artifactCache = ArtifactCache.getInstance(installDir);
         this.installDir = installDir;
+        this.filterManifest = filterManifest;
     }
 
     @Override
     public MavenVersionsResolver create(Collection<Repository> repositories) {
-        return new CachedVersionResolver(factory.create(repositories), artifactCache, system, session,
+        MavenVersionsResolver wildflyChannelVersionsResolver = factory.create(repositories);
+
+        Predicate<ArtifactVersion> artifactFiler;
+        if (filterManifest != null) {
+            artifactFiler = new ManifestBasedArtifactFilter(filterManifest, true);
+        } else {
+            artifactFiler = artifactVersion -> true;
+        }
+        FilteringVersionResolver filteringVersionResolver = new FilteringVersionResolver(artifactFiler, wildflyChannelVersionsResolver);
+
+        return new CachedVersionResolver(filteringVersionResolver, artifactCache, system, session,
                 (a)->getCurrentManifestVersion(a, installDir.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE)));
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryAuthenticationHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryAuthenticationHandler.java
@@ -1,0 +1,34 @@
+package org.wildfly.prospero.galleon;
+
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.wildfly.channel.Repository;
+
+/**
+ * Configures repository authentication when creating RemoteRepository instance.
+ */
+public class RepositoryAuthenticationHandler implements RepositoryConversionHandler {
+
+    private final Settings mavenSettings;
+
+    public RepositoryAuthenticationHandler(Settings mavenSettings) {
+        this.mavenSettings = mavenSettings;
+    }
+
+    @Override
+    public void accept(Repository repository, RemoteRepository.Builder builder) {
+        if (mavenSettings != null) {
+            Server server = mavenSettings.getServer(repository.getId());
+            if (server != null && (server.getUsername() != null || server.getPassword() != null)) {
+                Authentication authentication = new AuthenticationBuilder()
+                        .addUsername(server.getUsername())
+                        .addPassword(server.getPassword())
+                        .build();
+                builder.setAuthentication(authentication);
+            }
+        }
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryConversionHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryConversionHandler.java
@@ -1,0 +1,12 @@
+package org.wildfly.prospero.galleon;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.wildfly.channel.Repository;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Handles conversion of the Wildfly Channel Repository instance into Maven RemoteRepository.
+ */
+public interface RepositoryConversionHandler extends BiConsumer<Repository, RemoteRepository.Builder> {
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryFactory.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/RepositoryFactory.java
@@ -1,0 +1,30 @@
+package org.wildfly.prospero.galleon;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.wildfly.channel.Repository;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.wildfly.channel.maven.VersionResolverFactory.DEFAULT_REPOSITORY_POLICY;
+
+/**
+ * Converts Wildfly Channel repository instances into Maven RemoteRepository. Takes a list of handlers to configure
+ * specific aspects of the RemoteRepository configuration.
+ */
+public class RepositoryFactory implements Function<Repository, RemoteRepository> {
+
+    private final List<RepositoryConversionHandler> handlers;
+
+    public RepositoryFactory(List<RepositoryConversionHandler> handlers) {
+        this.handlers = handlers;
+    }
+
+    @Override
+    public RemoteRepository apply(Repository repository) {
+        final RemoteRepository.Builder builder = new RemoteRepository.Builder(repository.getId(), "default", repository.getUrl())
+                .setPolicy(DEFAULT_REPOSITORY_POLICY);
+        handlers.forEach(handler -> handler.accept(repository, builder));
+        return builder.build();
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/ArtifactVersion.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/ArtifactVersion.java
@@ -1,0 +1,22 @@
+package org.wildfly.prospero.galleon.artifactfiltering;
+
+public class ArtifactVersion {
+
+    final String groupId;
+    final String artifactId;
+    final String extension;
+    final String classifier;
+    final String version;
+
+    public static ArtifactVersion of(String groupId, String artifactId, String extension, String classifier, String version) {
+        return new ArtifactVersion(groupId, artifactId, extension, classifier, version);
+    }
+
+    private ArtifactVersion(String groupId, String artifactId, String extension, String classifier, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.extension = extension;
+        this.classifier = classifier;
+        this.version = version;
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/FilteringVersionResolver.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/FilteringVersionResolver.java
@@ -1,0 +1,59 @@
+package org.wildfly.prospero.galleon.artifactfiltering;
+
+import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ArtifactTransferException;
+import org.wildfly.channel.ChannelMetadataCoordinate;
+import org.wildfly.channel.spi.MavenVersionsResolver;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class FilteringVersionResolver implements MavenVersionsResolver  {
+
+    private final MavenVersionsResolver fallbackResolver;
+    private final Predicate<ArtifactVersion> predicate;
+
+    public FilteringVersionResolver(Predicate<ArtifactVersion> predicate, MavenVersionsResolver fallbackResolver) {
+        this.fallbackResolver = fallbackResolver;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public Set<String> getAllVersions(String groupId, String artifactId, String extension, String classifier) {
+        Set<String> allVersions = fallbackResolver.getAllVersions(groupId, artifactId, extension, classifier);
+        List<String> filteredVersions = allVersions.stream()
+                .filter(version ->
+                        predicate.test(ArtifactVersion.of(groupId, artifactId, extension, classifier, version)))
+                .toList();
+        return new HashSet<>(filteredVersions);
+    }
+
+    @Override
+    public File resolveArtifact(String groupId, String artifactId, String extension, String classifier, String version) throws ArtifactTransferException {
+        return fallbackResolver.resolveArtifact(groupId, artifactId, extension, classifier, version);
+    }
+
+    @Override
+    public List<File> resolveArtifacts(List<ArtifactCoordinate> coordinates) throws ArtifactTransferException {
+        return fallbackResolver.resolveArtifacts(coordinates);
+    }
+
+    @Override
+    public List<URL> resolveChannelMetadata(List<? extends ChannelMetadataCoordinate> manifestCoords) throws ArtifactTransferException {
+        return fallbackResolver.resolveChannelMetadata(manifestCoords);
+    }
+
+    @Override
+    public String getMetadataReleaseVersion(String groupId, String artifactId) {
+        return fallbackResolver.getMetadataReleaseVersion(groupId, artifactId);
+    }
+
+    @Override
+    public String getMetadataLatestVersion(String groupId, String artifactId) {
+        return fallbackResolver.getMetadataLatestVersion(groupId, artifactId);
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/ManifestBasedArtifactFilter.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/artifactfiltering/ManifestBasedArtifactFilter.java
@@ -1,0 +1,54 @@
+package org.wildfly.prospero.galleon.artifactfiltering;
+
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestMapper;
+import org.wildfly.channel.Stream;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Filters artifact versions based on provided manifest (which must contain version patterns).
+ */
+public class ManifestBasedArtifactFilter implements Predicate<ArtifactVersion> {
+
+    private final ChannelManifest channelManifest;
+    private final boolean allowMissingStreams;
+
+    public ManifestBasedArtifactFilter(Path manifestFile, boolean allowMissingStreams) {
+        try {
+            channelManifest = ChannelManifestMapper.fromString(Files.readString(manifestFile));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        this.allowMissingStreams = allowMissingStreams;
+    }
+
+    public boolean test(ArtifactVersion artifactVersion) {
+        Optional<Stream> streamOptional = channelManifest.findStreamFor(artifactVersion.groupId, artifactVersion.artifactId);
+        if (streamOptional.isEmpty()) {
+            if (allowMissingStreams) {
+                return true;
+            } else {
+                throw new RuntimeException(String.format("Missing filter stream for %s:%s",
+                        artifactVersion.groupId, artifactVersion.artifactId));
+            }
+        }
+        Stream stream = streamOptional.get();
+        if (stream.getVersionPattern() != null) {
+            return stream.getVersionPattern().asPredicate().test(artifactVersion.version);
+        } else if (stream.getVersion() != null) {
+            return stream.getVersion().equals(artifactVersion.version);
+        } else {
+            throw new RuntimeException(String.format(
+                    "Either version pattern or version must be provided by the manifest stream. " +
+                    "Neither was provided for %s:%s.",
+                    artifactVersion.groupId, artifactVersion.artifactId));
+        }
+    }
+
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/MavenOptionsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/MavenOptionsTest.java
@@ -17,12 +17,15 @@
 
 package org.wildfly.prospero.api;
 
+import org.assertj.core.api.Assumptions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Path;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -154,6 +157,21 @@ public class MavenOptionsTest {
                 .build();
         base.write(target);
         assertEquals(base, MavenOptions.read(target));
+    }
+
+    @Test
+    public void defaultMavenSettings() {
+        MavenOptions options = MavenOptions.builder().build();
+        assertThat(options.getMavenSettingsPath()).isEqualTo(Path.of(System.getProperty("user.home"), ".m2/settings.xml"));
+    }
+
+    @Test
+    public void notExistingMavenSettings() {
+        Path notExistingPath = Path.of(UUID.randomUUID().toString());
+        Assumptions.assumeThat(notExistingPath).doesNotExist();
+
+        MavenOptions options = MavenOptions.builder().setMavenSettingsPath(notExistingPath).build();
+        assertThat(options.getMavenSettings()).isNull();
     }
 
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzerTest.java
@@ -53,7 +53,7 @@ public class GalleonFeaturePackAnalyzerTest {
         final List<Channel> channels = List.of(new Channel.Builder()
                 .addRepository("local-test", repoHome.toUri().toString())
                 .build());
-        final Set<String> featurePacks = new GalleonFeaturePackAnalyzer(channels, msm).getFeaturePacks(temp.newFile().toPath(), provisioningConfig);
+        final Set<String> featurePacks = new GalleonFeaturePackAnalyzer(channels, msm, null).getFeaturePacks(temp.newFile().toPath(), provisioningConfig);
         assertThat(featurePacks)
                 .containsOnly("org.test:pack-two", "org.test:pack-one");
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzerTest.java
@@ -53,7 +53,7 @@ public class GalleonFeaturePackAnalyzerTest {
         final List<Channel> channels = List.of(new Channel.Builder()
                 .addRepository("local-test", repoHome.toUri().toString())
                 .build());
-        final Set<String> featurePacks = new GalleonFeaturePackAnalyzer(channels, msm, null).getFeaturePacks(temp.newFile().toPath(), provisioningConfig);
+        final Set<String> featurePacks = new GalleonFeaturePackAnalyzer(channels, msm, null, null).getFeaturePacks(temp.newFile().toPath(), provisioningConfig);
         assertThat(featurePacks)
                 .containsOnly("org.test:pack-two", "org.test:pack-one");
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/MavenProxyHandlerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/MavenProxyHandlerTest.java
@@ -22,10 +22,13 @@ import org.junit.Test;
 import org.wildfly.channel.Repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class MavenProxyHandlerTest {
+
+    private RemoteRepository.Builder builder(Repository repository) {
+        return new RemoteRepository.Builder(repository.getId(), "default", repository.getUrl());
+    }
 
     @After
     public void clearProperties() {
@@ -44,35 +47,50 @@ public class MavenProxyHandlerTest {
 
     @Test
     public void noProxiesAddedIfSettingsAreNotPresent() throws Exception {
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
 
-        assertNull(result.getProxy());
+        assertNull(builder.build().getProxy());
     }
 
     @Test
     public void addUnauthenticatedHttpProxy() throws Exception {
         System.setProperty("http.proxyHost", "http://proxy");
         System.setProperty("http.proxyPort", "8888");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
 
-        assertThat(result.getProxy())
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy())
                 .hasFieldOrPropertyWithValue("host", "http://proxy")
                 .hasFieldOrPropertyWithValue("port", 8888);
 
-        assertNull(MavenProxyHandler.addProxySettings(new Repository("test", "https://foo.bar")).getProxy());
+        repo = new Repository("test", "https://foo.bar");
+        builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+        assertNull(builder.build().getProxy());
     }
 
     @Test
     public void addUnauthenticatedHttpsProxy() throws Exception {
         System.setProperty("https.proxyHost", "http://proxy");
         System.setProperty("https.proxyPort", "8888");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "https://foo.bar"));
 
-        assertThat(result.getProxy())
+        Repository repo = new Repository("test", "https://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy())
                 .hasFieldOrPropertyWithValue("host", "http://proxy")
                 .hasFieldOrPropertyWithValue("port", 8888);
 
-        assertNull(MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar")).getProxy());
+        repo = new Repository("test", "http://foo.bar");
+        builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertNull(builder.build().getProxy());
     }
 
     @Test
@@ -81,12 +99,16 @@ public class MavenProxyHandlerTest {
         System.setProperty("https.proxyPort", "8888");
         System.setProperty("https.proxyUser", "test");
         System.setProperty("https.proxyPassword", "pwd");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "https://foo.bar"));
 
-        assertThat(result.getProxy())
-                .hasFieldOrPropertyWithValue("host", "http://proxy")
-                .hasFieldOrPropertyWithValue("port", 8888);
-        assertNotNull(result.getProxy().getAuthentication());
+        Repository repo = new Repository("test", "https://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy()).satisfies(proxy -> {
+            assertThat(proxy.getHost()).isEqualTo("http://proxy");
+            assertThat(proxy.getPort()).isEqualTo(8888);
+            assertThat(proxy.getAuthentication()).isNotNull();
+        });
     }
 
     @Test
@@ -95,12 +117,18 @@ public class MavenProxyHandlerTest {
         System.setProperty("http.proxyPort", "8888");
         System.setProperty("http.proxyUser", "test");
         System.setProperty("http.proxyPassword", "pwd");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
 
-        assertThat(result.getProxy())
-                .hasFieldOrPropertyWithValue("host", "http://proxy")
-                .hasFieldOrPropertyWithValue("port", 8888);
-        assertNotNull(result.getProxy().getAuthentication());
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy()).satisfies(proxy -> {
+            assertThat(proxy.getHost()).isEqualTo("http://proxy");
+            assertThat(proxy.getPort()).isEqualTo(8888);
+            assertThat(proxy.getAuthentication()).isNotNull();
+        });
     }
 
     @Test
@@ -108,20 +136,29 @@ public class MavenProxyHandlerTest {
         System.setProperty("http.proxyHost", "http://proxy");
         System.setProperty("http.proxyPort", "8888");
         System.setProperty("http.proxyPassword", "pwd");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
 
-        assertThat(result.getProxy())
-                .hasFieldOrPropertyWithValue("host", "http://proxy")
-                .hasFieldOrPropertyWithValue("port", 8888);
-        assertNull(result.getProxy().getAuthentication());
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy()).satisfies(proxy -> {
+            assertThat(proxy.getHost()).isEqualTo("http://proxy");
+            assertThat(proxy.getPort()).isEqualTo(8888);
+            assertThat(proxy.getAuthentication()).isNull();
+        });
     }
 
     @Test
     public void defaultPortTo80IfNotPresent() throws Exception {
         System.setProperty("http.proxyHost", "http://proxy");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
 
-        assertThat(result.getProxy())
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertThat(builder.build().getProxy())
                 .hasFieldOrPropertyWithValue("host", "http://proxy")
                 .hasFieldOrPropertyWithValue("port", 80);
     }
@@ -130,18 +167,32 @@ public class MavenProxyHandlerTest {
     public void skipProxyIfHostExcluded() throws Exception {
         System.setProperty("http.proxyHost", "http://proxy");
         System.setProperty("http.nonProxyHosts", "foo.bar");
-        final RemoteRepository result = MavenProxyHandler.addProxySettings(new Repository("test", "http://foo.bar"));
 
-        assertNull(result.getProxy());
+        Repository repo = new Repository("test", "http://foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+
+        assertNull(builder.build().getProxy());
     }
 
     @Test
     public void skipProxyIfRepositoryUrlInvalid() throws Exception {
         System.setProperty("http.proxyHost", "http://proxy");
 
-        assertNull(MavenProxyHandler.addProxySettings(new Repository("test", "http:foo.bar")).getProxy());
-        assertNull(MavenProxyHandler.addProxySettings(new Repository("test", "httpfoo.bar")).getProxy());
-        assertNull(MavenProxyHandler.addProxySettings(new Repository("test", "")).getProxy());
+        Repository repo = new Repository("test", "https:foo.bar");
+        RemoteRepository.Builder builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+        assertNull(builder.build().getProxy());
+
+        repo = new Repository("test", "https:foo.bar");
+        builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+        assertNull(builder.build().getProxy());
+
+        repo = new Repository("test", "");
+        builder = builder(repo);
+        MavenProxyHandler.addProxySettings(repo, builder);
+        assertNull(builder.build().getProxy());
     }
 
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/RepositoryAuthenticationHandlerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/RepositoryAuthenticationHandlerTest.java
@@ -1,0 +1,87 @@
+package org.wildfly.prospero.galleon;
+
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Test;
+import org.wildfly.channel.Repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RepositoryAuthenticationHandlerTest {
+
+    private final RemoteRepository.Builder builder = new RemoteRepository.Builder("test", "default", "...");
+
+    private Settings mavenSettings() {
+        Server server = new Server();
+        server.setId("test");
+        server.setUsername("username");
+        server.setPassword("password");
+
+        Settings settings = new Settings();
+        settings.addServer(server);
+
+        return settings;
+    }
+
+    @Test
+    public void testAuthenticationSet() throws Exception {
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(mavenSettings());
+        Repository repo = new Repository("test", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication().toString()).isEqualTo("username=username, password=***");
+    }
+
+    @Test
+    public void testAuthenticationSetForDifferentServerId() throws Exception {
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(mavenSettings());
+        Repository repo = new Repository("other", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication()).isNull();
+    }
+
+    @Test
+    public void testNoMavenSettings() throws Exception {
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(null);
+        Repository repo = new Repository("test", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication()).isNull();
+    }
+
+    @Test
+    public void testPasswordNull() throws Exception {
+        Settings settings = mavenSettings();
+        settings.getServer("test").setPassword(null);
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(settings);
+        Repository repo = new Repository("test", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication().toString()).isEqualTo("username=username");
+    }
+
+    @Test
+    public void testUsernameNull() throws Exception {
+        Settings settings = mavenSettings();
+        settings.getServer("test").setUsername(null);
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(settings);
+        Repository repo = new Repository("test", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication().toString()).isEqualTo("password=***");
+    }
+
+    @Test
+    public void testUsernameAndPasswordNull() throws Exception {
+        Settings settings = mavenSettings();
+        settings.getServer("test").setUsername(null);
+        settings.getServer("test").setPassword(null);
+        RepositoryAuthenticationHandler handler = new RepositoryAuthenticationHandler(settings);
+        Repository repo = new Repository("test", "https://repo");
+        handler.accept(repo, builder);
+
+        assertThat(builder.build().getAuthentication()).isNull();
+    }
+}


### PR DESCRIPTION
This introduces:

* The `--maven-settings` parameter to point prospero to the maven settings.xml file (defaults to ~/.m2/settings.xml). The settings file is then used by prospero to extract authentication credentials for Maven repositories.
* The `--filter-manifest`, that adds the ability to add an additional method of filtering available artifacts. This is used in case that the main input channel uses versionPatterns or no versions at all and resolves to the latest available artifact version. We would presently use it to filter out dependencies for specific EAP release (8.1 / 8.2) from a shared maven repo.
* Updates the wildfly-channel lib and prospero-metadata to versions that support accessing authenticated files over HTTP. This is used in cases when some channel metadata (manifest, blocklist) are referred as URLs rather, than Maven coordinates, and require HTTP authentication. The auth token can be provided as env variable ()`WILDFLY_CHANNEL_HTTP_AUTH_TOKEN` or system property (`org.wildfly.channel.http.auth.token`). See https://github.com/wildfly/wildfly-channel/pull/402