### PR TITLE
[WFCORE-6934] Server startup marker file is not a reliable method to detect when the server is running

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -18,6 +18,9 @@ package org.wildfly.prospero.actions;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -25,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,6 +92,7 @@ import org.wildfly.prospero.updates.UpdateSet;
 public class ApplyCandidateAction {
     public static final Path STANDALONE_STARTUP_MARKER = Path.of("standalone", "tmp", "startup-marker");
     public static final Path DOMAIN_STARTUP_MARKER = Path.of("domain", "tmp", "startup-marker");
+    public static final Path RUNNING_LOCK_FILE = Path.of(".installation", "running.lock");
     public static final String CANDIDATE_CHANNEL_NAME_LIST = "candidate_properties.yaml";
     private final Path updateDir;
     private final Path installationDir;
@@ -397,7 +402,22 @@ public class ApplyCandidateAction {
     }
 
     private boolean targetServerIsRunning() {
-        return Files.exists(installationDir.resolve(STANDALONE_STARTUP_MARKER)) || Files.exists(installationDir.resolve(DOMAIN_STARTUP_MARKER));
+        return isLockHeld(installationDir.resolve(RUNNING_LOCK_FILE));
+    }
+
+    private static boolean isLockHeld(Path lockFile) {
+        if (!Files.exists(lockFile)) {
+            return false;
+        }
+        try (FileChannel channel = FileChannel.open(lockFile, StandardOpenOption.WRITE, StandardOpenOption.READ)) {
+            try (FileLock lock = channel.tryLock()) {
+                return lock == null;
+            }
+        } catch (OverlappingFileLockException e) {
+            return true;
+        } catch (IOException e) {
+            return true;
+        }
     }
 
     private void updateMetadata(Type operation) throws IOException, MetadataException {

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -319,29 +319,19 @@ public class ApplyCandidateActionTest {
     }
 
     @Test
-    public void targetStandaloneServerHasToBeStopped() throws Exception {
+    public void targetServerHasToBeStopped() throws Exception {
         createSimpleFeaturePacks();
 
         install(installationPath, FPL_100);
         prepareUpdate(updatePath, installationPath, FPL_101);
 
-        Files.createDirectories(installationPath.resolve(ApplyCandidateAction.STANDALONE_STARTUP_MARKER.getParent()));
-        Files.writeString(installationPath.resolve(ApplyCandidateAction.STANDALONE_STARTUP_MARKER), "test");
-
-        assertThrows(ProvisioningException.class, () -> new ApplyCandidateAction(installationPath, updatePath).applyUpdate(ApplyCandidateAction.Type.UPDATE));
-    }
-
-    @Test
-    public void targetDomainServerHasToBeStopped() throws Exception {
-        createSimpleFeaturePacks();
-
-        install(installationPath, FPL_100);
-        prepareUpdate(updatePath, installationPath, FPL_101);
-
-        Files.createDirectories(installationPath.resolve(ApplyCandidateAction.DOMAIN_STARTUP_MARKER.getParent()));
-        Files.writeString(installationPath.resolve(ApplyCandidateAction.DOMAIN_STARTUP_MARKER), "test");
-
-        assertThrows(ProvisioningException.class, () -> new ApplyCandidateAction(installationPath, updatePath).applyUpdate(ApplyCandidateAction.Type.UPDATE));
+        Path lockFile = installationPath.resolve(ApplyCandidateAction.RUNNING_LOCK_FILE);
+        Files.createDirectories(lockFile.getParent());
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(lockFile,
+                java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ);
+             java.nio.channels.FileLock lock = channel.lock()) {
+            assertThrows(ProvisioningException.class, () -> new ApplyCandidateAction(installationPath, updatePath).applyUpdate(ApplyCandidateAction.Type.UPDATE));
+        }
     }
 
     @Test


### PR DESCRIPTION
depends on https://github.com/wildfly/wildfly-core/pull/6756/
Issue: https://github.com/wildfly/wildfly-core/pull/6756/