### PR TITLE
Fix feature pack family productization

### DIFF
--- a/dist/build/pom.xml
+++ b/dist/build/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.wildfly.prospero</groupId>
         <artifactId>prospero-dist</artifactId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/dist/common/pom.xml
+++ b/dist/common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.wildfly.prospero</groupId>
     <artifactId>prospero-dist</artifactId>
-    <version>1.4.0.Beta5-SNAPSHOT</version>
+    <version>1.4.0.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/dist/docs/pom.xml
+++ b/dist/docs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.wildfly.prospero</groupId>
     <artifactId>prospero-dist</artifactId>
-    <version>1.4.0.Beta5-SNAPSHOT</version>
+    <version>1.4.0.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.prospero</groupId>
         <artifactId>prospero</artifactId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dist/standalone-galleon-pack/pom.xml
+++ b/dist/standalone-galleon-pack/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.wildfly.prospero</groupId>
         <artifactId>prospero-dist</artifactId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/dist/wildfly-galleon-pack/pom.xml
+++ b/dist/wildfly-galleon-pack/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.wildfly.prospero</groupId>
     <artifactId>prospero-dist</artifactId>
-    <version>1.4.0.Beta5-SNAPSHOT</version>
+    <version>1.4.0.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
+++ b/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
@@ -24,7 +24,7 @@
 
 <build xmlns="urn:wildfly:feature-pack-build:3.5" producer="org.wildfly.prospero:prospero-wildfly-galleon-pack">
   <dependencies>
-    <dependency group-id="${prospero.base.feature-pack.groupId}" artifact-id="${prospero.base.feature-pack.artifactId}" allowedFamily="wildfly:jakarta-ee-10+">
+    <dependency group-id="${prospero.base.feature-pack.groupId}" artifact-id="${prospero.base.feature-pack.artifactId}" allowedFamily="${prospero.base.feature-pack.family-prefix}:jakarta-ee-10+">
       <packages inherit="true"/>
       <default-configs inherit="false"/>
     </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>prospero</artifactId>
         <groupId>org.wildfly.prospero</groupId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.wildfly.prospero</groupId>
     <artifactId>prospero</artifactId>
-    <version>1.4.0.Beta5-SNAPSHOT</version>
+    <version>1.4.0.Final</version>
     <packaging>pom</packaging>
 
     <name>Prospero Parent</name>
@@ -63,7 +63,7 @@
         <connection>scm:git:git@github.com:wildfly/prospero.git</connection>
         <developerConnection>scm:git:git@github.com:wildfly/prospero.git</developerConnection>
         <url>https://github.com/wildfly/prospero</url>
-        <tag>HEAD</tag>
+        <tag>1.4.0.Final</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <prospero.target.server>Wildfly</prospero.target.server>
         <prospero.base.feature-pack.groupId>org.wildfly</prospero.base.feature-pack.groupId>
         <prospero.base.feature-pack.artifactId>wildfly-ee-galleon-pack</prospero.base.feature-pack.artifactId>
+        <prospero.base.feature-pack.family-prefix>wildfly</prospero.base.feature-pack.family-prefix>
         <prospero.test.base.channel.groupId>org.wildfly.channels</prospero.test.base.channel.groupId>
         <prospero.test.base.channel.artifactId>wildfly</prospero.test.base.channel.artifactId>
         <prospero.test.base.channel.version>${version.org.wildfly.galleon-pack}</prospero.test.base.channel.version>

--- a/prospero-cli/pom.xml
+++ b/prospero-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wildfly.prospero</groupId>
         <artifactId>prospero</artifactId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/prospero-common/pom.xml
+++ b/prospero-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wildfly.prospero</groupId>
         <artifactId>prospero</artifactId>
-        <version>1.4.0.Beta5-SNAPSHOT</version>
+        <version>1.4.0.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The galleon family is hardcoded to "widfly", but during productization needs to be overridden to "jboss-eap".