### PR TITLE
[JBEAP-34144] - prospero should not print error if user reject the update

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
@@ -218,7 +218,7 @@ public class UpdateToVersionTest extends CliTestBase {
                 ),
                 (ExecutionUtils.ExecutionResult e) -> {
                     try {
-                        e.assertReturnCode(ReturnCodes.PROCESSING_ERROR);
+                        e.assertReturnCode(ReturnCodes.SUCCESS);
                         assertThat(e.getCommandOutput())
                                 .contains("The update will downgrade following channels:")
                                 .contains("  * test-channel: 1.0.1 (Logical version 1.0.1)  ->  1.0.0 (Logical version 1.0.0)");

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -155,30 +155,34 @@ public class UpdateCommand extends AbstractParentCommand {
             Path targetDir = null;
             try {
                 targetDir = Files.createTempDirectory("update-candidate");
-                if (buildUpdate(updateAction, targetDir, console::confirmUpdates)) {
-                    console.println("");
-                    console.buildUpdatesComplete();
-
-                    ApplyCandidateAction applyCandidateAction = actionFactory.applyUpdate(installDir, targetDir);
-                    final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
-                    if (!conflicts.isEmpty()) {
-                        FileConflictPrinter.print(conflicts, console);
-
-                        if (noConflictsOnly) {
-                            throw CliMessages.MESSAGES.cancelledByConfilcts();
-                        }
-
-                        if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithUpdate(), "",
-                                CliMessages.MESSAGES.updateCancelled())) {
-                            return false;
-                        }
-                    }
-
-                    console.println(CliMessages.MESSAGES.applyingUpdates());
-                    applyCandidateAction.applyUpdate(ApplyCandidateAction.Type.UPDATE);
-                } else {
+                BuildResult result = buildUpdate(updateAction, targetDir, console::confirmUpdates);
+                if (result == BuildResult.ERROR) {
                     return false;
                 }
+                if (result != BuildResult.BUILT) {
+                    return true;
+                }
+
+                console.println("");
+                console.buildUpdatesComplete();
+
+                ApplyCandidateAction applyCandidateAction = actionFactory.applyUpdate(installDir, targetDir);
+                final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
+                if (!conflicts.isEmpty()) {
+                    FileConflictPrinter.print(conflicts, console);
+
+                    if (noConflictsOnly) {
+                        throw CliMessages.MESSAGES.cancelledByConfilcts();
+                    }
+
+                    if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithUpdate(), "",
+                            CliMessages.MESSAGES.updateCancelled())) {
+                        return false;
+                    }
+                }
+
+                console.println(CliMessages.MESSAGES.applyingUpdates());
+                applyCandidateAction.applyUpdate(ApplyCandidateAction.Type.UPDATE);
             } catch (IOException e) {
                 throw ProsperoLogger.ROOT_LOGGER.unableToCreateTemporaryDirectory(e);
             } finally {
@@ -229,7 +233,7 @@ public class UpdateCommand extends AbstractParentCommand {
 
                 try (UpdateAction updateAction = actionFactory.update(installationDir, overrideChannels,
                         mavenOptions, console)) {
-                    if (buildUpdate(updateAction, candidateDirectory, console::confirmBuildUpdates)) {
+                    if (buildUpdate(updateAction, candidateDirectory, console::confirmBuildUpdates) == BuildResult.BUILT) {
                         console.println("");
                         console.buildUpdatesComplete();
                         console.println(CliMessages.MESSAGES.updateCandidateGenerated(candidateDirectory));
@@ -560,11 +564,18 @@ public class UpdateCommand extends AbstractParentCommand {
         )
         protected List<String> versions = new ArrayList<>();
 
+        enum BuildResult {
+            BUILT,
+            CANCELLED,
+            NO_UPDATES,
+            ERROR
+        }
+
         public UpdateBuildCommand(CliConsole console, ActionFactory actionFactory) {
             super(console, actionFactory);
         }
 
-        protected boolean buildUpdate(UpdateAction updateAction, Path updateDirectory,
+        protected BuildResult buildUpdate(UpdateAction updateAction, Path updateDirectory,
                 Supplier<Boolean> confirmation) throws OperationException, ProvisioningException {
             // Log version overrides being applied
             if (!versions.isEmpty()) {
@@ -595,7 +606,7 @@ public class UpdateCommand extends AbstractParentCommand {
                 if (hasUnexpectedDowngrade(downgrades)) {
                     log.errorf("Found unexpected downgrade(s) - user must explicitly specify version overrides");
                     printer.printUnexpectedDowngradesError(downgrades, spec);
-                    return false;
+                    return BuildResult.ERROR;
                 } else {
                     log.infof("All downgrades are explicitly requested via version overrides");
                 }
@@ -603,23 +614,23 @@ public class UpdateCommand extends AbstractParentCommand {
                 if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithUpdate(), "",
                         CliMessages.MESSAGES.updateCancelled())) {
                     log.infof("Update cancelled by user due to downgrades");
-                    return false;
+                    return BuildResult.CANCELLED;
                 }
                 log.infof("User confirmed downgrade operation");
             }
 
             console.updatesFound(updateSet.getArtifactUpdates(), updateSet.getChannelVersionChanges());
             if (updateSet.isEmpty()) {
-                return false;
+                return BuildResult.NO_UPDATES;
             }
 
             if (!yes && !confirmation.get()) {
-                return true;
+                return BuildResult.CANCELLED;
             }
 
             updateAction.buildUpdate(updateDirectory.toAbsolutePath());
 
-            return true;
+            return BuildResult.BUILT;
         }
 
         private boolean hasUnexpectedDowngrade(List<ChannelVersionChange> downgrades) {

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateCommandTest.java
@@ -655,6 +655,82 @@ public class UpdateCommandTest extends AbstractMavenCommandTest {
                 ;
     }
 
+    @Test
+    public void userCancellingDowngradeConfirmationReturnsSuccess() throws Exception {
+        when(updateAction.findUpdates()).thenReturn(new UpdateSet(List.of(change("1.0.0", "1.0.1")),
+                List.of(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.1").setType(ChannelVersion.Type.MAVEN).build(),
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.0").setType(ChannelVersion.Type.MAVEN).build()
+                ))));
+        setDenyConfirm(true, 1);
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.PERFORM,
+                CliConstants.DIR, installationDir.toAbsolutePath().toString(),
+                CliConstants.MANIFEST_VERSIONS, "test-channel::1.0.0");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertEquals(1, getAskedConfirmation());
+        Mockito.verify(updateAction, never()).buildUpdate(any());
+        Mockito.verify(applyCandidateAction, never()).applyUpdate(any());
+    }
+
+    @Test
+    public void userCancellingBuildUpdateConfirmationInPrepareReturnsSuccess() throws Exception {
+        when(updateAction.findUpdates()).thenReturn(new UpdateSet(List.of(change("1.0.0", "1.0.1"))));
+        setDenyConfirm(true);
+        final Path updatePath = tempFolder.newFolder().toPath();
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.PREPARE,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, installationDir.toAbsolutePath().toString());
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertEquals(1, getAskedConfirmation());
+        Mockito.verify(updateAction, never()).buildUpdate(any());
+    }
+
+    @Test
+    public void userCancellingDowngradeConfirmationInPrepareReturnsSuccess() throws Exception {
+        when(updateAction.findUpdates()).thenReturn(new UpdateSet(List.of(change("1.0.0", "1.0.1")),
+                List.of(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.1").setType(ChannelVersion.Type.MAVEN).build(),
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.0").setType(ChannelVersion.Type.MAVEN).build()
+                ))));
+        setDenyConfirm(true, 1);
+        final Path updatePath = tempFolder.newFolder().toPath();
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.PREPARE,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, installationDir.toAbsolutePath().toString(),
+                CliConstants.MANIFEST_VERSIONS, "test-channel::1.0.0");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertEquals(1, getAskedConfirmation());
+        Mockito.verify(updateAction, never()).buildUpdate(any());
+    }
+
+    @Test
+    public void unexpectedDowngradeInPrepareReturnsSuccess() throws Exception {
+        when(updateAction.findUpdates()).thenReturn(new UpdateSet(List.of(change("1.0.0", "1.0.1")),
+                List.of(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.1").setType(ChannelVersion.Type.MAVEN).build(),
+                        new ChannelVersion.Builder().setPhysicalVersion("1.0.0").setType(ChannelVersion.Type.MAVEN).build()
+                ))));
+        final Path updatePath = tempFolder.newFolder().toPath();
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.PREPARE,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, installationDir.toAbsolutePath().toString(),
+                CliConstants.YES);
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertEquals(0, getAskedConfirmation());
+        Mockito.verify(updateAction, never()).buildUpdate(any());
+        assertThat(getStandardOutput())
+                .contains("The update would introduce one or more unexpected channel downgrades.")
+                .contains("test-channel: 1.0.1  ->  1.0.0");
+    }
+
     private Path generateTwoChannelConfiguration() throws IOException {
         // build a list of two channels
         final List<Channel> channels = List.of(


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/JBEAP-34144