### PR TITLE
Enable setting cyclonedx properties in galleon

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
@@ -59,6 +59,8 @@ public class GalleonUtils {
     public static final String JBOSS_FORK_EMBEDDED_VALUE = "true";
     public static final String JBOSS_BULK_RESOLVE_PROPERTY = "jboss-bulk-resolve-artifacts";
     public static final String JBOSS_BULK_RESOLVE_VALUE = "true";
+    public static final String JBOSS_CYCLONEDX_PROPERTY = "jboss-cyclonedx";
+    public static final String JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY = "jboss-cyclonedx-fail-on-error";
     public static final String MODULE_PATH_PROPERTY = "module.path";
     public static final String PRINT_ONLY_CONFLICTS_PROPERTY = "print-only-conflicts";
     public static final String PRINT_ONLY_CONFLICTS_VALUE = "true";
@@ -84,10 +86,22 @@ public class GalleonUtils {
             options.put(PRINT_ONLY_CONFLICTS_PROPERTY, PRINT_ONLY_CONFLICTS_VALUE);
             options.put(STORE_INPUT_PROVISIONING_CONFIG_PROPERTY, STORE_INPUT_PROVISIONING_CONFIG_VALUE);
             options.put(STORE_PROVISIONED_ARTIFACTS, STORE_PROVISIONED_ARTIFACTS_VALUE);
+
             String resetSysProp = System.getProperty(OPTION_RESET_EMBEDDED_SYSTEM_PROPERTIES, "");
             if (!resetSysProp.equals("-")) {
                 options.put(OPTION_RESET_EMBEDDED_SYSTEM_PROPERTIES, resetSysProp);
             }
+
+           String cycloneDxValue = System.getProperty(JBOSS_CYCLONEDX_PROPERTY, "");
+            if (!cycloneDxValue.isBlank()) {
+                options.put(JBOSS_CYCLONEDX_PROPERTY, cycloneDxValue);
+            }
+
+            String cycloneDxFailOnErrorValue = System.getProperty(JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY, "");
+            if (!cycloneDxFailOnErrorValue.isBlank()) {
+                options.put(JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY, cycloneDxFailOnErrorValue);
+            }
+
             if (logger.isTraceEnabled()) {
                 logger.trace("Executing galleon");
                 logger.trace("System properties:");

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.wildfly.prospero.galleon.GalleonUtils.JBOSS_MODULES_SETTINGS_XML_URL;
@@ -90,6 +91,47 @@ public class GalleonUtilsTest {
                 .doesNotExist();
         assertThat(System.getProperties())
                 .doesNotContainKey(JBOSS_MODULES_SETTINGS_XML_URL);
+    }
+
+    @Test
+    public void testCycloneDxProperties() throws Exception {
+        String cycloneDx = System.getProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY);
+        String cycloneDxFailOnError = System.getProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY);
+        try {
+            System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY, "true");
+            System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY, "true");
+            GalleonUtils.executeGalleon((options) -> {
+                assertEquals("true", options.get(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY));
+                assertEquals("true", options.get(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY));
+            }, Paths.get("test"));
+
+            System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY, "false");
+            System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY, "false");
+            GalleonUtils.executeGalleon((options) -> {
+                assertEquals("false", options.get(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY));
+                assertEquals("false", options.get(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY));
+            }, Paths.get("test"));
+
+            System.clearProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY);
+            System.clearProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY);
+            GalleonUtils.executeGalleon((options) -> {
+                assertFalse(options.containsKey(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY));
+                assertFalse(options.containsKey(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY));
+            }, Paths.get("test"));
+
+        } finally {
+            // Reset original values
+            if (cycloneDx == null) {
+                System.clearProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY);
+            } else {
+                System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_PROPERTY, cycloneDx);
+            }
+            if (cycloneDxFailOnError == null) {
+                System.clearProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY);
+            } else {
+                System.setProperty(GalleonUtils.JBOSS_CYCLONEDX_FAIL_ON_ERROR_PROPERTY, cycloneDxFailOnError);
+            }
+        }
     }
 
     private static Path urlToPath(String url) {


### PR DESCRIPTION
These are properties that control whether SBOM should be generated during provisioning, and whether prospero should fail on SBOM generation failure.